### PR TITLE
Rolls back to previous CLJS version (v1.7.28) to avoid compile error

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
 
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
-                 [org.clojure/clojurescript "1.7.48"]
+                 [org.clojure/clojurescript "1.7.28"]
                  [compojure "1.4.0"]
                  [ring/ring-core "1.4.0"]
                  [ring/ring-jetty-adapter "1.4.0"]


### PR DESCRIPTION
CLJS v1.7.48 introduced a compile error:
`a.lang.StringIndexOutOfBoundsException: String index out of range: 1 at java.lang.String.charAt (String.java:658)`
