### PR TITLE
Improve test semantics

### DIFF
--- a/test/dash_test/all_tests.cljs
+++ b/test/dash_test/all_tests.cljs
@@ -3,8 +3,8 @@
             [dash-test.tests.util :as util-tests]
             [dash-test.tests.core :as core-tests]))
 
-(defn tests []
-    [{:nsp "dash.util"
-      :tests util-tests/tests}
-     {:nsp "dash.core"
-      :tests core-tests/tests}])
+(def tests
+  [{:nsp "dash.util"
+    :tests util-tests/tests}
+   {:nsp "dash.core"
+    :tests core-tests/tests}])

--- a/test/dash_test/core.cljs
+++ b/test/dash_test/core.cljs
@@ -11,7 +11,7 @@
 (defn refresh-tests! [state]
   "Refreshes the state cursor with new tests and updated refresh counter."
   (let [reloads (inc (:reload-count @state))
-        all-tests (tests/tests)
+        all-tests tests/tests
         new-tests (mapv #(assoc % :tests (insert-ids (:tests %))) all-tests)]
     (swap! state assoc :reload-count reloads
                        :tests new-tests)))


### PR DESCRIPTION
Now a static vector of tests instead of a `defn`
